### PR TITLE
[Fix] #49 근/원거리 모든 몬스터 공격 확인 및 수정 완료

### DIFF
--- a/ProjectAIF/Assets/Prefabs/Monster/BasicMonster(Goblin).prefab
+++ b/ProjectAIF/Assets/Prefabs/Monster/BasicMonster(Goblin).prefab
@@ -3471,7 +3471,7 @@ Rigidbody:
   m_ImplicitCom: 1
   m_ImplicitTensor: 1
   m_UseGravity: 1
-  m_IsKinematic: 0
+  m_IsKinematic: 1
   m_Interpolate: 1
   m_Constraints: 80
   m_CollisionDetection: 0
@@ -3514,12 +3514,12 @@ MonoBehaviour:
   <MoveSpeed>k__BackingField: 8
   <AttackRate>k__BackingField: 1
   <AttackRange>k__BackingField: 3
-  <Exp>k__BackingField: 0
+  <Exp>k__BackingField: 50
   ScreamAc: {fileID: 8300000, guid: 934126bb761feca4d846e9ab2c5b4ba3, type: 3}
   DeadAc: {fileID: 8300000, guid: c1ab8021f199d7545a646252533386d3, type: 3}
   AttackAc: {fileID: 8300000, guid: c5b441f42e2306945b5f7f115f973649, type: 3}
   DamagedAc: {fileID: 8300000, guid: c1ab8021f199d7545a646252533386d3, type: 3}
-  _animator: {fileID: 0}
+  _animator: {fileID: 584468020116178354}
   _detectionHeight: 1
   _attackTargetLayer:
     serializedVersion: 2

--- a/ProjectAIF/Assets/Prefabs/Monster/BowMonster(Archer).prefab
+++ b/ProjectAIF/Assets/Prefabs/Monster/BowMonster(Archer).prefab
@@ -42,9 +42,9 @@ GameObject:
   - component: {fileID: 4706893418795395519}
   - component: {fileID: 7135731102554350814}
   - component: {fileID: 6630121972855396192}
+  - component: {fileID: 6403168424411031479}
   - component: {fileID: 6492381203223687731}
   - component: {fileID: 6033771536591465119}
-  - component: {fileID: 6403168424411031479}
   m_Layer: 6
   m_Name: BowMonster(Archer)
   m_TagString: Enemy
@@ -93,7 +93,7 @@ Rigidbody:
   m_ImplicitCom: 1
   m_ImplicitTensor: 1
   m_UseGravity: 1
-  m_IsKinematic: 0
+  m_IsKinematic: 1
   m_Interpolate: 1
   m_Constraints: 80
   m_CollisionDetection: 0
@@ -118,6 +118,36 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 0.5, y: 1.8, z: 0.4}
   m_Center: {x: 0, y: 0.9, z: 0}
+--- !u!114 &6403168424411031479
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7627008493037234255}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 254ea02b966b4e64997362f71ba768bc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <Damage>k__BackingField: 15
+  <Defence>k__BackingField: 0
+  <Hp>k__BackingField: 15
+  <MoveSpeed>k__BackingField: 10
+  <AttackRate>k__BackingField: 1
+  <AttackRange>k__BackingField: 15
+  <Exp>k__BackingField: 50
+  ScreamAc: {fileID: 8300000, guid: 9be7f2b969f0a544b89ba17d060f9558, type: 3}
+  DeadAc: {fileID: 8300000, guid: ac14f452bc7e6c74880604d6f46af64b, type: 3}
+  AttackAc: {fileID: 8300000, guid: c6e476bb7fe4b08458a752179404b9f1, type: 3}
+  DamagedAc: {fileID: 8300000, guid: d055067d998f25d42aec47dd7353663d, type: 3}
+  _animator: {fileID: 3000217489480690987}
+  _detectionHeight: 1
+  _attackTargetLayer:
+    serializedVersion: 2
+    m_Bits: 1073741952
+  _attackAnimationDelay: 1
+  _projectile: {fileID: 636280962206556035}
 --- !u!195 &6492381203223687731
 NavMeshAgent:
   m_ObjectHideFlags: 0
@@ -158,36 +188,6 @@ MonoBehaviour:
   OnMovingEvent:
     m_PersistentCalls:
       m_Calls: []
---- !u!114 &6403168424411031479
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7627008493037234255}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 254ea02b966b4e64997362f71ba768bc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  <Damage>k__BackingField: 0
-  <Defence>k__BackingField: 0
-  <Hp>k__BackingField: 0
-  <MoveSpeed>k__BackingField: 0
-  <AttackRate>k__BackingField: 0
-  <AttackRange>k__BackingField: 0
-  <Exp>k__BackingField: 0
-  ScreamAc: {fileID: 8300000, guid: 9be7f2b969f0a544b89ba17d060f9558, type: 3}
-  DeadAc: {fileID: 8300000, guid: ac14f452bc7e6c74880604d6f46af64b, type: 3}
-  AttackAc: {fileID: 8300000, guid: c6e476bb7fe4b08458a752179404b9f1, type: 3}
-  DamagedAc: {fileID: 8300000, guid: d055067d998f25d42aec47dd7353663d, type: 3}
-  _animator: {fileID: 0}
-  _detectionHeight: 0
-  _attackTargetLayer:
-    serializedVersion: 2
-    m_Bits: 0
-  _attackAnimationDelay: 0
-  _projectile: {fileID: 636280962206556035}
 --- !u!1001 &1861646723796767459
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -693,6 +693,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 249c135e43948ca4995fc26c238c058b, type: 3}
+--- !u!95 &3000217489480690987 stripped
+Animator:
+  m_CorrespondingSourceObject: {fileID: 5348263984606774366, guid: 249c135e43948ca4995fc26c238c058b, type: 3}
+  m_PrefabInstance: {fileID: 7177101908197878133}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &9170108659883374417 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2078680700503809572, guid: 249c135e43948ca4995fc26c238c058b, type: 3}

--- a/ProjectAIF/Assets/Prefabs/Monster/FastMonster(MiniSkeleton).prefab
+++ b/ProjectAIF/Assets/Prefabs/Monster/FastMonster(MiniSkeleton).prefab
@@ -60,7 +60,7 @@ Rigidbody:
   m_ImplicitCom: 1
   m_ImplicitTensor: 1
   m_UseGravity: 1
-  m_IsKinematic: 0
+  m_IsKinematic: 1
   m_Interpolate: 1
   m_Constraints: 80
   m_CollisionDetection: 0
@@ -103,14 +103,12 @@ MonoBehaviour:
   <MoveSpeed>k__BackingField: 15
   <AttackRate>k__BackingField: 1.5
   <AttackRange>k__BackingField: 3
-  <Exp>k__BackingField: 10
-  Player: {fileID: 1026817363066699652, guid: 3e21353bbfd230840b6757ad174ad54f, type: 3}
-  PlayerLevel: {fileID: 2846247506866570063, guid: 3e21353bbfd230840b6757ad174ad54f, type: 3}
+  <Exp>k__BackingField: 50
   ScreamAc: {fileID: 8300000, guid: 7729c927c5610d249b105dd45bfb0e42, type: 3}
   DeadAc: {fileID: 8300000, guid: 7108f7549a1c3b741a4378fd886c6637, type: 3}
   AttackAc: {fileID: 8300000, guid: 8a67cd189abcc48428d89ef8f72385f6, type: 3}
   DamagedAc: {fileID: 8300000, guid: af392a5a179d9ff4bad71d633488752a, type: 3}
-  _animator: {fileID: 0}
+  _animator: {fileID: 9174002997345964999}
   _detectionHeight: 1
   _attackTargetLayer:
     serializedVersion: 2
@@ -356,5 +354,10 @@ PrefabInstance:
 --- !u!4 &5939684398565228232 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2468889828458600031, guid: 4a46e821c58b5cd42b14eaab6d197266, type: 3}
+  m_PrefabInstance: {fileID: 8083606507787217047}
+  m_PrefabAsset: {fileID: 0}
+--- !u!95 &9174002997345964999 stripped
+Animator:
+  m_CorrespondingSourceObject: {fileID: 1116371902028168016, guid: 4a46e821c58b5cd42b14eaab6d197266, type: 3}
   m_PrefabInstance: {fileID: 8083606507787217047}
   m_PrefabAsset: {fileID: 0}

--- a/ProjectAIF/Assets/Prefabs/Monster/MagicMonster(Magician).prefab
+++ b/ProjectAIF/Assets/Prefabs/Monster/MagicMonster(Magician).prefab
@@ -11,9 +11,9 @@ GameObject:
   - component: {fileID: 3406293635287124182}
   - component: {fileID: 8070012004417008696}
   - component: {fileID: 4524991564846888585}
+  - component: {fileID: 8994762844079218669}
   - component: {fileID: -9149576617330343381}
   - component: {fileID: 6783861647833831221}
-  - component: {fileID: 8994762844079218669}
   m_Layer: 6
   m_Name: MagicMonster(Magician)
   m_TagString: Enemy
@@ -62,7 +62,7 @@ Rigidbody:
   m_ImplicitCom: 1
   m_ImplicitTensor: 1
   m_UseGravity: 1
-  m_IsKinematic: 0
+  m_IsKinematic: 1
   m_Interpolate: 1
   m_Constraints: 80
   m_CollisionDetection: 0
@@ -87,6 +87,36 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1, y: 2, z: 1}
   m_Center: {x: 0, y: 1, z: 0}
+--- !u!114 &8994762844079218669
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4255552051480737237}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 254ea02b966b4e64997362f71ba768bc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <Damage>k__BackingField: 10
+  <Defence>k__BackingField: 0
+  <Hp>k__BackingField: 10
+  <MoveSpeed>k__BackingField: 5
+  <AttackRate>k__BackingField: 3
+  <AttackRange>k__BackingField: 10
+  <Exp>k__BackingField: 50
+  ScreamAc: {fileID: 8300000, guid: 259e1e5868d91274c987cad6582507d6, type: 3}
+  DeadAc: {fileID: 8300000, guid: be4665aebe8866546a857817a7c073a4, type: 3}
+  AttackAc: {fileID: 8300000, guid: 8e2c22361a98c4b409ec0d6fb260da32, type: 3}
+  DamagedAc: {fileID: 8300000, guid: fea4941c5b1d2a3419ecadfecfc9c4d0, type: 3}
+  _animator: {fileID: 6133719234535162597}
+  _detectionHeight: 1
+  _attackTargetLayer:
+    serializedVersion: 2
+    m_Bits: 1073741952
+  _attackAnimationDelay: 1.2
+  _projectile: {fileID: 1120167827682631182}
 --- !u!195 &-9149576617330343381
 NavMeshAgent:
   m_ObjectHideFlags: 0
@@ -127,37 +157,6 @@ MonoBehaviour:
   OnMovingEvent:
     m_PersistentCalls:
       m_Calls: []
---- !u!114 &8994762844079218669
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4255552051480737237}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 254ea02b966b4e64997362f71ba768bc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  <Damage>k__BackingField: 0
-  <Defence>k__BackingField: 0
-  <Hp>k__BackingField: 0
-  <MoveSpeed>k__BackingField: 0
-  <AttackRate>k__BackingField: 0
-  <AttackRange>k__BackingField: 0
-  <Exp>k__BackingField: 0
-  Player: {fileID: 1026817363066699652, guid: 3e21353bbfd230840b6757ad174ad54f, type: 3}
-  PlayerLevel: {fileID: 2846247506866570063, guid: 3e21353bbfd230840b6757ad174ad54f, type: 3}
-  ScreamAc: {fileID: 8300000, guid: 259e1e5868d91274c987cad6582507d6, type: 3}
-  DeadAc: {fileID: 8300000, guid: be4665aebe8866546a857817a7c073a4, type: 3}
-  AttackAc: {fileID: 8300000, guid: 8e2c22361a98c4b409ec0d6fb260da32, type: 3}
-  DamagedAc: {fileID: 8300000, guid: fea4941c5b1d2a3419ecadfecfc9c4d0, type: 3}
-  _detectionHeight: 0
-  _attackTargetLayer:
-    serializedVersion: 2
-    m_Bits: 0
-  _attackAnimationDelay: 0
-  _projectile: {fileID: 1120167827682631182}
 --- !u!1 &6896524189090802232
 GameObject:
   m_ObjectHideFlags: 0
@@ -255,6 +254,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3478025250975259355, guid: cc2904f8420d54e45b80616562ff859c, type: 3}
   m_PrefabInstance: {fileID: 3180418169195419247}
   m_PrefabAsset: {fileID: 0}
+--- !u!95 &6133719234535162597 stripped
+Animator:
+  m_CorrespondingSourceObject: {fileID: 8735932539965035658, guid: cc2904f8420d54e45b80616562ff859c, type: 3}
+  m_PrefabInstance: {fileID: 3180418169195419247}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7599765726261660197
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -263,6 +267,22 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 3406293635287124182}
     m_Modifications:
+    - target: {fileID: -2261069208475463288, guid: 80e21d66121958941b6114733505e431, type: 3}
+      propertyPath: _moveSpeed
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: -2261069208475463288, guid: 80e21d66121958941b6114733505e431, type: 3}
+      propertyPath: _damageRate
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -2261069208475463288, guid: 80e21d66121958941b6114733505e431, type: 3}
+      propertyPath: _shootingMonster
+      value: 
+      objectReference: {fileID: 8994762844079218669}
+    - target: {fileID: -2261069208475463288, guid: 80e21d66121958941b6114733505e431, type: 3}
+      propertyPath: _shootingTransform
+      value: 
+      objectReference: {fileID: 2469366984184392328}
     - target: {fileID: 2234877065965353663, guid: 80e21d66121958941b6114733505e431, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -303,39 +323,40 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2914211445633676409, guid: 80e21d66121958941b6114733505e431, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3259349516129829736, guid: 80e21d66121958941b6114733505e431, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4306192468719605086, guid: 80e21d66121958941b6114733505e431, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 7420920763988562987, guid: 80e21d66121958941b6114733505e431, type: 3}
       propertyPath: m_Name
       value: ElectronicBall
       objectReference: {fileID: 0}
+    - target: {fileID: 7420920763988562987, guid: 80e21d66121958941b6114733505e431, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7420920763988562987, guid: 80e21d66121958941b6114733505e431, type: 3}
+      propertyPath: m_TagString
+      value: Enemy
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 7420920763988562987, guid: 80e21d66121958941b6114733505e431, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 4329267739148864229}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 80e21d66121958941b6114733505e431, type: 3}
 --- !u!1 &1120167827682631182 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7420920763988562987, guid: 80e21d66121958941b6114733505e431, type: 3}
   m_PrefabInstance: {fileID: 7599765726261660197}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &4329267739148864229
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1120167827682631182}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dfebf86914e263843a9b87592ae1a8ba, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _shootingMonster: {fileID: 0}
-  _shootingTransform: {fileID: 2469366984184392328}
-  _moveSpeed: 4
-  _damageRate: 1
 --- !u!4 &8535493856102969498 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2234877065965353663, guid: 80e21d66121958941b6114733505e431, type: 3}

--- a/ProjectAIF/Assets/Prefabs/Monster/NimbleMonster(Spider).prefab
+++ b/ProjectAIF/Assets/Prefabs/Monster/NimbleMonster(Spider).prefab
@@ -60,7 +60,7 @@ Rigidbody:
   m_ImplicitCom: 1
   m_ImplicitTensor: 1
   m_UseGravity: 1
-  m_IsKinematic: 0
+  m_IsKinematic: 1
   m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
@@ -103,12 +103,12 @@ MonoBehaviour:
   <MoveSpeed>k__BackingField: 10
   <AttackRate>k__BackingField: 0.3
   <AttackRange>k__BackingField: 4
-  <Exp>k__BackingField: 0
+  <Exp>k__BackingField: 50
   ScreamAc: {fileID: 8300000, guid: d6b2a91cedb99e74daf8c20cb4e99ee6, type: 3}
   DeadAc: {fileID: 8300000, guid: 3b146703d5011ce48ad91f4f6ec3a07d, type: 3}
   AttackAc: {fileID: 8300000, guid: c559c38e9d4edb94d9037b70d54c7cf7, type: 3}
   DamagedAc: {fileID: 8300000, guid: 9364407bd25dc6a419ba743f65e67e54, type: 3}
-  _animator: {fileID: 0}
+  _animator: {fileID: 266776744421449005}
   _detectionHeight: 1
   _attackTargetLayer:
     serializedVersion: 2

--- a/ProjectAIF/Assets/Prefabs/Monster/TankMonster(Golenm).prefab
+++ b/ProjectAIF/Assets/Prefabs/Monster/TankMonster(Golenm).prefab
@@ -60,7 +60,7 @@ Rigidbody:
   m_ImplicitCom: 1
   m_ImplicitTensor: 1
   m_UseGravity: 1
-  m_IsKinematic: 0
+  m_IsKinematic: 1
   m_Interpolate: 1
   m_Constraints: 80
   m_CollisionDetection: 0
@@ -103,12 +103,12 @@ MonoBehaviour:
   <MoveSpeed>k__BackingField: 10
   <AttackRate>k__BackingField: 2
   <AttackRange>k__BackingField: 5
-  <Exp>k__BackingField: 0
+  <Exp>k__BackingField: 50
   ScreamAc: {fileID: 8300000, guid: 5837ebed21829aa44afd9638495468b0, type: 3}
   DeadAc: {fileID: 8300000, guid: 1b1bc94272343d84f89d06e37577d294, type: 3}
   AttackAc: {fileID: 8300000, guid: 66ce15feba2c2e548b98f810770e75af, type: 3}
   DamagedAc: {fileID: 8300000, guid: 87739409cee2af24a86f8110dff67d70, type: 3}
-  _animator: {fileID: 0}
+  _animator: {fileID: 423262715638237420}
   _detectionHeight: 1
   _attackTargetLayer:
     serializedVersion: 2
@@ -463,6 +463,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3d2e6e9a35aebe848bcaf85c3ec6c0f1, type: 3}
+--- !u!95 &423262715638237420 stripped
+Animator:
+  m_CorrespondingSourceObject: {fileID: 4915082991154533488, guid: 3d2e6e9a35aebe848bcaf85c3ec6c0f1, type: 3}
+  m_PrefabInstance: {fileID: 4749708550398041244}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &5998680242799317654 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1357216421320936970, guid: 3d2e6e9a35aebe848bcaf85c3ec6c0f1, type: 3}

--- a/ProjectAIF/Assets/Prefabs/Monster/WarlikeMonster(Orc).prefab
+++ b/ProjectAIF/Assets/Prefabs/Monster/WarlikeMonster(Orc).prefab
@@ -60,7 +60,7 @@ Rigidbody:
   m_ImplicitCom: 1
   m_ImplicitTensor: 1
   m_UseGravity: 1
-  m_IsKinematic: 0
+  m_IsKinematic: 1
   m_Interpolate: 1
   m_Constraints: 80
   m_CollisionDetection: 0
@@ -103,13 +103,12 @@ MonoBehaviour:
   <MoveSpeed>k__BackingField: 8
   <AttackRate>k__BackingField: 1
   <AttackRange>k__BackingField: 3
-  <Exp>k__BackingField: 0
-  Player: {fileID: 1026817363066699652, guid: 3e21353bbfd230840b6757ad174ad54f, type: 3}
-  PlayerLevel: {fileID: 2846247506866570063, guid: 3e21353bbfd230840b6757ad174ad54f, type: 3}
+  <Exp>k__BackingField: 50
   ScreamAc: {fileID: 8300000, guid: 9585d86a2ee98eb49a3ae5c75fb51a5d, type: 3}
   DeadAc: {fileID: 8300000, guid: b9084cbdfebffc64daae98d25c68eab3, type: 3}
   AttackAc: {fileID: 8300000, guid: e2a17b3c4248f774b8f32360441e8edc, type: 3}
   DamagedAc: {fileID: 8300000, guid: 285c47faccb4ec84a846913a4429034d, type: 3}
+  _animator: {fileID: 8907373985192234389}
   _detectionHeight: 1
   _attackTargetLayer:
     serializedVersion: 2

--- a/ProjectAIF/Assets/Prefabs/Projectile/Arrow.prefab
+++ b/ProjectAIF/Assets/Prefabs/Projectile/Arrow.prefab
@@ -11,10 +11,10 @@ GameObject:
   - component: {fileID: 7912138013405447582}
   - component: {fileID: 6380575303655432537}
   - component: {fileID: 8089932086637340929}
-  - component: {fileID: 4512462588299738212}
-  m_Layer: 0
+  - component: {fileID: -7029864616689928304}
+  m_Layer: 6
   m_Name: Arrow
-  m_TagString: Untagged
+  m_TagString: Enemy
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -74,7 +74,7 @@ CapsuleCollider:
   m_Height: 1
   m_Direction: 2
   m_Center: {x: 0, y: 0, z: 0.5}
---- !u!54 &4512462588299738212
+--- !u!54 &-7029864616689928304
 Rigidbody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -97,9 +97,9 @@ Rigidbody:
   m_ImplicitCom: 1
   m_ImplicitTensor: 1
   m_UseGravity: 1
-  m_IsKinematic: 1
+  m_IsKinematic: 0
   m_Interpolate: 0
-  m_Constraints: 0
+  m_Constraints: 126
   m_CollisionDetection: 0
 --- !u!1 &3282057183928493575
 GameObject:
@@ -111,7 +111,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8080520172707470241}
   - component: {fileID: 1366742610318559982}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: ArrowTrail
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -257,7 +257,7 @@ GameObject:
   - component: {fileID: 2560732536650677107}
   - component: {fileID: 629435879993804070}
   - component: {fileID: 8964845083528079686}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: ArrowMesh
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/ProjectAIF/Assets/Prefabs/Projectile/ElectronicBall.prefab
+++ b/ProjectAIF/Assets/Prefabs/Projectile/ElectronicBall.prefab
@@ -93,6 +93,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2234877065965353663}
+  - component: {fileID: -2261069208475463288}
   - component: {fileID: 4949770534053142562}
   - component: {fileID: 7019917673772761790}
   m_Layer: 0
@@ -118,6 +119,22 @@ Transform:
   - {fileID: 295339061741703360}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &-2261069208475463288
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7420920763988562987}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dfebf86914e263843a9b87592ae1a8ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _shootingMonster: {fileID: 0}
+  _shootingTransform: {fileID: 0}
+  _moveSpeed: 4
+  _damageRate: 1
 --- !u!135 &4949770534053142562
 SphereCollider:
   m_ObjectHideFlags: 0
@@ -162,9 +179,9 @@ Rigidbody:
   m_ImplicitCom: 1
   m_ImplicitTensor: 1
   m_UseGravity: 1
-  m_IsKinematic: 1
+  m_IsKinematic: 0
   m_Interpolate: 0
-  m_Constraints: 0
+  m_Constraints: 126
   m_CollisionDetection: 0
 --- !u!1001 &8063513565881203684
 PrefabInstance:

--- a/ProjectAIF/Assets/Scripts/Projectile/ArrowType.cs
+++ b/ProjectAIF/Assets/Scripts/Projectile/ArrowType.cs
@@ -12,14 +12,16 @@ public class ArrowType : MonoBehaviour
     private void OnEnable()
     {
         transform.position = _shootingTransform.position;
+        transform.rotation = _shootingTransform.rotation;
     }
     
     private void OnCollisionEnter(Collision other)
     {
-        if (!(other is IDamageable)) return;
+        Debug.Log($"충돌 : {other.gameObject.name}");
         
-        (other as IDamageable).TakeDamage(_shootingMonster.DamageCalc(_shootingMonster.Damage));
+        other.gameObject.GetComponent<IDamageable>()?.TakeDamage(_shootingMonster.DamageCalc(_shootingMonster.Damage));
         Debug.Log($"{_shootingMonster.name} : 명중! {_shootingMonster.DamageCalc(_shootingMonster.Damage)} 피해");
+        gameObject.SetActive(false);
     }
 
     private void Update()


### PR DESCRIPTION
[Fix]
- 몬스터 프리팹 수정
  - 잘못 적용 된 참조 및 누락 부분 수정
  - 경험치 50으로 일괄 조정
  - 리짓 바디 키네마틱 적용
- 투사체 프리팹 수정
  - 리짓 바디 키네마틱 해제(이제 타격 정상적으로 작동)
  - 리짓 바디 전 방향 회전 불가 적용(궤도 안정화)
- 투사체 스크립트 조정
  - 컴포넌트를 불러오지 못해 데미지 못주는 현상 해결