### PR TITLE
[Fix] #52 몬스터 능력치 초기화 외 1건

### DIFF
--- a/ProjectAIF/.gitignore
+++ b/ProjectAIF/.gitignore
@@ -104,4 +104,4 @@ Assets/Imports/**
 ## custom
 *.vs*
 *.idea*
-*Test/*
+*/Test/*

--- a/ProjectAIF/Assets/Prefabs/Monster/BasicMonster(Goblin).prefab
+++ b/ProjectAIF/Assets/Prefabs/Monster/BasicMonster(Goblin).prefab
@@ -3511,10 +3511,10 @@ MonoBehaviour:
   <Damage>k__BackingField: 5
   <Defence>k__BackingField: 0
   <Hp>k__BackingField: 15
-  <MoveSpeed>k__BackingField: 8
+  <MoveSpeed>k__BackingField: 12
   <AttackRate>k__BackingField: 1
   <AttackRange>k__BackingField: 3
-  <Exp>k__BackingField: 50
+  <Exp>k__BackingField: 5
   ScreamAc: {fileID: 8300000, guid: 934126bb761feca4d846e9ab2c5b4ba3, type: 3}
   DeadAc: {fileID: 8300000, guid: c1ab8021f199d7545a646252533386d3, type: 3}
   AttackAc: {fileID: 8300000, guid: c5b441f42e2306945b5f7f115f973649, type: 3}

--- a/ProjectAIF/Assets/Prefabs/Monster/BowMonster(Archer).prefab
+++ b/ProjectAIF/Assets/Prefabs/Monster/BowMonster(Archer).prefab
@@ -132,11 +132,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   <Damage>k__BackingField: 15
   <Defence>k__BackingField: 0
-  <Hp>k__BackingField: 15
-  <MoveSpeed>k__BackingField: 10
+  <Hp>k__BackingField: 25
+  <MoveSpeed>k__BackingField: 20
   <AttackRate>k__BackingField: 1
   <AttackRange>k__BackingField: 15
-  <Exp>k__BackingField: 50
+  <Exp>k__BackingField: 15
   ScreamAc: {fileID: 8300000, guid: 9be7f2b969f0a544b89ba17d060f9558, type: 3}
   DeadAc: {fileID: 8300000, guid: ac14f452bc7e6c74880604d6f46af64b, type: 3}
   AttackAc: {fileID: 8300000, guid: c6e476bb7fe4b08458a752179404b9f1, type: 3}

--- a/ProjectAIF/Assets/Prefabs/Monster/FastMonster(MiniSkeleton).prefab
+++ b/ProjectAIF/Assets/Prefabs/Monster/FastMonster(MiniSkeleton).prefab
@@ -100,10 +100,10 @@ MonoBehaviour:
   <Damage>k__BackingField: 5
   <Defence>k__BackingField: 0
   <Hp>k__BackingField: 10
-  <MoveSpeed>k__BackingField: 15
+  <MoveSpeed>k__BackingField: 30
   <AttackRate>k__BackingField: 1.5
   <AttackRange>k__BackingField: 3
-  <Exp>k__BackingField: 50
+  <Exp>k__BackingField: 5
   ScreamAc: {fileID: 8300000, guid: 7729c927c5610d249b105dd45bfb0e42, type: 3}
   DeadAc: {fileID: 8300000, guid: 7108f7549a1c3b741a4378fd886c6637, type: 3}
   AttackAc: {fileID: 8300000, guid: 8a67cd189abcc48428d89ef8f72385f6, type: 3}

--- a/ProjectAIF/Assets/Prefabs/Monster/MagicMonster(Magician).prefab
+++ b/ProjectAIF/Assets/Prefabs/Monster/MagicMonster(Magician).prefab
@@ -101,8 +101,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   <Damage>k__BackingField: 10
   <Defence>k__BackingField: 0
-  <Hp>k__BackingField: 10
-  <MoveSpeed>k__BackingField: 5
+  <Hp>k__BackingField: 100
+  <MoveSpeed>k__BackingField: 10
   <AttackRate>k__BackingField: 3
   <AttackRange>k__BackingField: 10
   <Exp>k__BackingField: 50

--- a/ProjectAIF/Assets/Prefabs/Monster/NimbleMonster(Spider).prefab
+++ b/ProjectAIF/Assets/Prefabs/Monster/NimbleMonster(Spider).prefab
@@ -99,11 +99,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   <Damage>k__BackingField: 5
   <Defence>k__BackingField: 0
-  <Hp>k__BackingField: 20
-  <MoveSpeed>k__BackingField: 10
-  <AttackRate>k__BackingField: 0.3
+  <Hp>k__BackingField: 25
+  <MoveSpeed>k__BackingField: 15
+  <AttackRate>k__BackingField: 0.1
   <AttackRange>k__BackingField: 4
-  <Exp>k__BackingField: 50
+  <Exp>k__BackingField: 7
   ScreamAc: {fileID: 8300000, guid: d6b2a91cedb99e74daf8c20cb4e99ee6, type: 3}
   DeadAc: {fileID: 8300000, guid: 3b146703d5011ce48ad91f4f6ec3a07d, type: 3}
   AttackAc: {fileID: 8300000, guid: c559c38e9d4edb94d9037b70d54c7cf7, type: 3}

--- a/ProjectAIF/Assets/Prefabs/Monster/TankMonster(Golenm).prefab
+++ b/ProjectAIF/Assets/Prefabs/Monster/TankMonster(Golenm).prefab
@@ -98,12 +98,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   <Damage>k__BackingField: 25
-  <Defence>k__BackingField: 10
-  <Hp>k__BackingField: 50
-  <MoveSpeed>k__BackingField: 10
-  <AttackRate>k__BackingField: 2
+  <Defence>k__BackingField: 0
+  <Hp>k__BackingField: 150
+  <MoveSpeed>k__BackingField: 15
+  <AttackRate>k__BackingField: 3
   <AttackRange>k__BackingField: 5
-  <Exp>k__BackingField: 50
+  <Exp>k__BackingField: 25
   ScreamAc: {fileID: 8300000, guid: 5837ebed21829aa44afd9638495468b0, type: 3}
   DeadAc: {fileID: 8300000, guid: 1b1bc94272343d84f89d06e37577d294, type: 3}
   AttackAc: {fileID: 8300000, guid: 66ce15feba2c2e548b98f810770e75af, type: 3}

--- a/ProjectAIF/Assets/Prefabs/Monster/WarlikeMonster(Orc).prefab
+++ b/ProjectAIF/Assets/Prefabs/Monster/WarlikeMonster(Orc).prefab
@@ -97,13 +97,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59b70aad5121bf243824922d65dc1617, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <Damage>k__BackingField: 15
+  <Damage>k__BackingField: 20
   <Defence>k__BackingField: 0
-  <Hp>k__BackingField: 25
-  <MoveSpeed>k__BackingField: 8
-  <AttackRate>k__BackingField: 1
+  <Hp>k__BackingField: 35
+  <MoveSpeed>k__BackingField: 12
+  <AttackRate>k__BackingField: 2
   <AttackRange>k__BackingField: 3
-  <Exp>k__BackingField: 50
+  <Exp>k__BackingField: 10
   ScreamAc: {fileID: 8300000, guid: 9585d86a2ee98eb49a3ae5c75fb51a5d, type: 3}
   DeadAc: {fileID: 8300000, guid: b9084cbdfebffc64daae98d25c68eab3, type: 3}
   AttackAc: {fileID: 8300000, guid: e2a17b3c4248f774b8f32360441e8edc, type: 3}

--- a/ProjectAIF/Assets/Scripts/Enemy/MeleeMonster.cs
+++ b/ProjectAIF/Assets/Scripts/Enemy/MeleeMonster.cs
@@ -21,6 +21,7 @@ public class MeleeMonster : Monster, IAttackable, IDamageable, ITargetable
     private Coroutine _deathCoroutine;
     private ITargetable _targetable;
     private Transform _targetTransform;
+    private int _targetDef;
 
     
     private void Awake()
@@ -37,7 +38,7 @@ public class MeleeMonster : Monster, IAttackable, IDamageable, ITargetable
     {
         if (_targetable is IDamageable)
         {
-            Attack(DamageCalc(Damage));
+            Attack(DamageCalc());
         }
     }
     
@@ -63,6 +64,7 @@ public class MeleeMonster : Monster, IAttackable, IDamageable, ITargetable
         _monsterMovement = GetComponent<MonsterMovement>();
         _animator = GetComponentInChildren<Animator>();
         _playerLevel = GameObject.FindWithTag("Player").GetComponent<PlayerLevel>();
+        _playerStatus = GameObject.FindWithTag("Player").GetComponent<PlayerStatus>();
     }
     
     public void Attack(int damage)
@@ -74,11 +76,9 @@ public class MeleeMonster : Monster, IAttackable, IDamageable, ITargetable
         _attackCoroutine = StartCoroutine(AttackCoroutine(damage));
     }
 
-    private int DamageCalc(int attValue)
+    private int DamageCalc()
     {
-        //TODO : 플레이어/크리스탈 방어력 들어있는 컴포넌트 지정해서 삽입
-        int targetDef = 0;
-        return attValue - targetDef;
+        return Damage - _targetDef;
     }
 
     private IEnumerator AttackCoroutine(int damage)
@@ -159,15 +159,30 @@ public class MeleeMonster : Monster, IAttackable, IDamageable, ITargetable
             
             _targetTransform = hit.transform;
             _targetable = hit.transform.GetComponent<ITargetable>();
+            if (hit.transform.CompareTag("Player"))
+            {
+                if (_playerStatus.Defense != null)
+                {
+                    _targetDef = _playerStatus.Defense;
+                }
+                else
+                {
+                    _targetDef = 0;
+                    Debug.Log("플레이어 방어력 참조 실패");
+                }
+            }
+            else
+            {
+                _targetDef = 0;
+            }
             
-            //_targetDef = hit.transform.gameObject.Defense();
             Debug.Log($"{gameObject.name} : 목표 포착");
         }
         else
         {
             _targetable = null;
             _targetTransform = null;
-            //_targetDef = 0;
+            _targetDef = 0;
             Debug.Log($"{gameObject.name} : 목표 수색중");
         }
     }

--- a/ProjectAIF/Assets/Scripts/Enemy/RangeMonster.cs
+++ b/ProjectAIF/Assets/Scripts/Enemy/RangeMonster.cs
@@ -22,6 +22,7 @@ public class RangeMonster : Monster, IAttackable, IDamageable, ITargetable
     private Coroutine _attackCoroutine;
     private Coroutine _deathCoroutine;
     private ITargetable _targetable;
+    private int _targetDef;
     
     public Transform _targetTransform { get; private set; }
 
@@ -41,7 +42,7 @@ public class RangeMonster : Monster, IAttackable, IDamageable, ITargetable
     {
         if (_targetable is IDamageable)
         {
-            Attack(DamageCalc(Damage));
+            Attack(DamageCalc());
         }
     }
     
@@ -68,6 +69,7 @@ public class RangeMonster : Monster, IAttackable, IDamageable, ITargetable
         _monsterMovement = GetComponent<MonsterMovement>();
         _animator = GetComponentInChildren<Animator>();
         _playerLevel = GameObject.FindWithTag("Player").GetComponent<PlayerLevel>();
+        _playerStatus = GameObject.FindWithTag("Player").GetComponent<PlayerStatus>();
     }
     
     private void Scream(bool isMoving)
@@ -92,17 +94,15 @@ public class RangeMonster : Monster, IAttackable, IDamageable, ITargetable
 
         if (_attackCoroutine  != null) return;
         
-        _attackCoroutine = StartCoroutine(AttackCoroutine(damage));
+        _attackCoroutine = StartCoroutine(AttackCoroutine());
     }
 
-    public int DamageCalc(int attValue)
+    public int DamageCalc()
     {
-        //TODO : 플레이어/크리스탈 방어력 들어있는 컴포넌트 지정해서 삽입
-        int targetDef = 0;
-        return attValue - targetDef;
+        return Damage - _targetDef;
     }
 
-    private IEnumerator AttackCoroutine(int damage)
+    private IEnumerator AttackCoroutine()
     {
         while (true)
         {
@@ -180,14 +180,30 @@ public class RangeMonster : Monster, IAttackable, IDamageable, ITargetable
             _targetTransform = hit.transform;
             _targetable = hit.transform.GetComponent<ITargetable>();
             
-            //_targetDef = hit.transform.gameObject.Defense();
+            if (hit.transform.CompareTag("Player"))
+            {
+                if (_playerStatus.Defense != null)
+                {
+                    _targetDef = _playerStatus.Defense;
+                }
+                else
+                {
+                    _targetDef = 0;
+                    Debug.Log("플레이어 방어력 참조 실패");
+                }
+            }
+            else
+            {
+                _targetDef = 0;
+            }
+            
             Debug.Log($"{gameObject.name} : 목표 포착");
         }
         else
         {
             _targetable = null;
             _targetTransform = null;
-            //_targetDef = 0;
+            _targetDef = 0;
             Debug.Log($"{gameObject.name} : 목표 수색중");
         }
     }

--- a/ProjectAIF/Assets/Scripts/Projectile/ArrowType.cs
+++ b/ProjectAIF/Assets/Scripts/Projectile/ArrowType.cs
@@ -19,8 +19,8 @@ public class ArrowType : MonoBehaviour
     {
         Debug.Log($"충돌 : {other.gameObject.name}");
         
-        other.gameObject.GetComponent<IDamageable>()?.TakeDamage(_shootingMonster.DamageCalc(_shootingMonster.Damage));
-        Debug.Log($"{_shootingMonster.name} : 명중! {_shootingMonster.DamageCalc(_shootingMonster.Damage)} 피해");
+        other.gameObject.GetComponent<IDamageable>()?.TakeDamage(_shootingMonster.DamageCalc());
+        Debug.Log($"{_shootingMonster.name} : 명중! {_shootingMonster.DamageCalc()} 피해");
         gameObject.SetActive(false);
     }
 

--- a/ProjectAIF/Assets/Scripts/Projectile/PenetrateType.cs
+++ b/ProjectAIF/Assets/Scripts/Projectile/PenetrateType.cs
@@ -60,8 +60,8 @@ public class PenetrateType : MonoBehaviour
             
             if (!other.gameObject.CompareTag("Enemy"))
             {
-                other.gameObject.GetComponent<IDamageable>()?.TakeDamage(_shootingMonster.DamageCalc(_shootingMonster.Damage));
-                Debug.Log($"{_shootingMonster.name} : 명중! {_shootingMonster.DamageCalc(_shootingMonster.Damage)} 피해");
+                other.gameObject.GetComponent<IDamageable>()?.TakeDamage(_shootingMonster.DamageCalc());
+                Debug.Log($"{_shootingMonster.name} : 명중! {_shootingMonster.DamageCalc()} 피해");
             }
             
             yield return YieldContainer.WaitForSeconds(_damageRate);


### PR DESCRIPTION
[Fix]
- 문서 기반 몬스터 능력치 초기화
   - https://docs.google.com/spreadsheets/d/1uqNi5V0_cBf6VPs4zMGWv35-BM_yjQft-kTResEIiWk/edit?gid=94913715#gid=94913715
- 몬스터 공격 과정에서 플레이어의 방어력을 인식하도록 수정